### PR TITLE
Remove -q flag from walk_the_path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,6 @@ fn seek_the_path() -> bool {
 fn walk_the_path() -> bool {
     Command::new("cargo")
         .arg("test")
-        .arg("-q")
         .status()
         .unwrap()
         .success()


### PR DESCRIPTION
Not sure what the -q flag is for, but it's breaking Cargo when I try to run it. Is it not available for 1.0.0? Let me know if there's a need to keep it.
