### PR TITLE
Create path_to_enlightenment.rs in build.rs before `Cargo run`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,4 @@
 name = "koans"
 version = "0.2.0"
 authors = ["Mike MacDonald <crazymykl@gmail.com>"]
+build = "build.rs"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+use std::fs::{OpenOptions};
+
+fn main() {
+    OpenOptions::new().create(true)
+        .open("src/path_to_enlightenment.rs")
+        .unwrap();
+}


### PR DESCRIPTION
I'm opening this PR as one of two possible solutions to #16, which involves `cargo run` failing on a fresh checkout due to the inclusion of the `path_to_enlightenment.rs` file in `.gitignore`. The solutions are their benefits/drawbacks are as follows:

1) Merge this PR which removes `src/path_to_enlightenment.rs` from the `.gitignore` file and restores it to git. This will make `cargo run` work on a fresh checkout which is a big benefit to those trying to learn Rust who are coming to this project fresh. A potential disadvantage of checking in `path_to_enlightenment.rs` is it will be a small inconvenience during development, as the file will need to be altered manually from time to time and will need to be excluded from commits by the developer.

2) Leave `src/path_to_enlightenment.rs` in the `.gitignore` file and add instructions to the README that users must create the file before they'll be able to run the koans. This will make things slightly less clear and convenient for the user, with the benefit of making things slightly more convenient for koan developers.

Out of these two solutions, I prefer number 1, as I think this project should be made as user friendly as possible in order to make Rust more welcoming to newcomers. I have also considered the possibility of having `main.rs` check whether the file exists yet, and to create it if it doesn't, but because of the `mod path_to_enlightenment;` at the bottom of `main.rs`, the file won't even compile with `path_to_enlightenment.rs` missing.
