### PR TITLE
Fixed initial cargo run due to invalid argument error

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ use std::fs::{OpenOptions};
 
 fn main() {
     OpenOptions::new().create(true)
+        .write(true)
         .open("src/path_to_enlightenment.rs")
         .unwrap();
 }


### PR DESCRIPTION
I am running on linux with rust 1.8.0 had an error in the build.rs when trying to run `cargo run` on the initial git (see stack trace at the end).
Since I have not had this issue for older rust versions, I assume it occurs with rust 1.8.0 - so I am not sure if I break older rust versions and I am also not sure if I break the git for Windows.

Probably this is realted to: https://github.com/rust-lang/rust/pull/26772

```
Compiling koans v0.2.0 (file:///home/mputz/Projects/test)
failed to run custom build command for `koans v0.2.0 (file:///home/mputz/Projects/test)`
Process didn't exit successfully: `/home/mputz/Projects/test/target/debug/build/koans-f317790ee7949dab/build-script-build` (exit code: 101)
--- stderr
thread '<main>' panicked at 'called `Result::unwrap()` on an `Err` value: Error { repr: Os { code: 22, message: "Invalid argument" } }', ../src/libcore/result.rs:746
stack backtrace:
  1: 0xb76e616c - sys::backtrace::tracing::imp::write::hcd9c6b761d959e16Xcv
     2: 0xb76e8631 - panicking::default_handler::_$u7b$$u7b$closure$u7d$$u7d$::closure.44492
        3: 0xb76e822d - panicking::default_handler::hda9238d9f8e0ef0alSz
           4: 0xb76e1de9 - sys_common::unwind::begin_unwind_inner::h7224040aaffdbb98g1t
              5: 0xb76e2047 - sys_common::unwind::begin_unwind_fmt::h9d1eda8fc60b8ae3m0t
                 6: 0xb76e5621 - rust_begin_unwind
                    7: 0xb7716dc0 - panicking::panic_fmt::h559080aff49c30cclcM
                       8: 0xb76e0c48 - result::unwrap_failed::h8267018095847856913
                                       at ../src/libcore/macros.rs:29
                                          9: 0xb76e091b - result::Result<T, E>::unwrap::h17069360763103869926
                                                          at ../src/libcore/result.rs:687
                                                            10: 0xb76e07e9 - main::h97927c14109a19dbgaa
                                                                            at /home/mputz/Projects/test/build.rs:4
                                                                              11: 0xb76e7eaa - sys_common::unwind::try::try_fn::h10144795978809605109
                                                                                12: 0xb76e5557 - __rust_try
                                                                                  13: 0xb76e7969 - rt::lang_start::he74f855a6a899d05rKz
                                                                                    14: 0xb76e116d - main
                                                                                      15: 0xb74caa82 - __libc_start_main
                                                                                        16: 0xb76e0610 - <unknown>
```
