### PR TITLE
Fix needing to rerun cargo on each koan

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,20 @@
 use std::fs::{OpenOptions};
+use std::io::{Write,ErrorKind};
 
 fn main() {
-    OpenOptions::new().create(true)
+    let path = OpenOptions::new().create_new(true)
         .write(true)
-        .open("src/path_to_enlightenment.rs")
-        .unwrap();
+        .open("src/path_to_enlightenment.rs");
+
+    match path {
+        Err(error) => {
+            match error.kind() {
+                ErrorKind::AlreadyExists => {},
+                _ => panic!("{}", error),
+            }
+        },
+        Ok(f) => {
+            write!(&f, "koan!(\"the_truth\");\n").unwrap();
+        },
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,11 @@ fn seek_the_path() -> bool {
 #[cfg(not(test))]
 fn walk_the_path() -> bool {
     Command::new("cargo")
+        .arg("clean")
+        .status()
+        .unwrap()
+        .success();
+    Command::new("cargo")
         .arg("test")
         .arg("-q")
         .status()


### PR DESCRIPTION
I believe the issue was mostly due to rust-lang/cargo#2426. From there I just made it so that when you run for the first time, `the_truth` should be added by default. I'm totally new to rust, so please forgive any wonkiness in this solution. I'm happy to go back to the drawing board or just drop this on the ground if it doesn't make any sense!

I believe this should fix crazymykl/rust-koans#26.