### PR TITLE
Add string to koans

### DIFF
--- a/src/koans.txt
+++ b/src/koans.txt
@@ -4,6 +4,7 @@ boolean
 array
 integer
 vec
+string
 hash_map
 struct
 ownership


### PR DESCRIPTION
The `string` koan was missing from the path to enlightenment 