### PR TITLE
Corrected wording of &str-to-String concatenation.

### DIFF
--- a/src/koans/string.rs
+++ b/src/koans/string.rs
@@ -35,7 +35,7 @@ fn string_to_slice() {
     assert!(slice == "Can't stop me now");
 }
 
-// You can concat a String to a &str at the end
+// You can concat a &str to a String at the end
 #[test]
 fn strings_with_strs() {
     let hello = "Hello ".to_string();


### PR DESCRIPTION
I'm pretty sure that you can only concatenate &str to String, but then again, I'm doing these Koans to learn Rust :smiley:.