### PR TITLE
Fix typo in vec koan

### DIFF
--- a/src/koans/vec.rs
+++ b/src/koans/vec.rs
@@ -86,7 +86,7 @@ fn truncate() {
     assert_eq!(vector, vec![1, 2]);
 }
 
-// New elements can be stuffed into mutable Vecors
+// New elements can be stuffed into mutable Vectors
 #[test]
 fn insert() {
     let mut vector = vec![1, 2, 3, 4, 5];


### PR DESCRIPTION
Fixing a typo ("Vecors" -> "Vectors") I've found while solving the koans.