### PR TITLE
update README to reflect `cloning` repo info

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Currently, a Rust version of 1.3.0 or higher is recommended.
 
 ## The Path to Englightenment
 
-In order to run the koans, simply run:
+In order to run the koans, **Clone** this repository, and from the root folder simply run:
 
 ```
 $ cargo run


### PR DESCRIPTION
The README is confusing as it simply says run `cargo run` as if it is a binary and can be executed anywhere. Added info on cloning the repo and actually running it from the root of the repo. Though it looks like a trivial change, current explanation is very confusing for new rust users.