### PR TITLE
Allow `const-err` lint

### DIFF
--- a/src/koans/array.rs
+++ b/src/koans/array.rs
@@ -20,6 +20,7 @@ fn array_empty() {
 // that error in this example.
 #[test]
 #[should_panic]
+#[allow(const_err)]
 fn out_of_index() {
     let arr: [&'static str; 5] = ["rust", "is", "mostly", "for", "nerds"];
     arr[__];


### PR DESCRIPTION
For version `1.36.0` of the compiler, the `const-err` lint produces an error.

```
error: index out of bounds: the len is 5 but the index is 5
  --> src/koans/array.rs:26:5
   |
26 |     arr[5];
   |     ^^^^^^
   |
   = note: #[deny(const_err)] on by default
```

```
$ rustc -W help
const-err  deny     constant evaluation detected erroneous expression
```

I think this might cause an unnecessary hiccup for a newcomer working through the koans.