### PR TITLE
Fix for Issue #40

### DIFF
--- a/src/koans/array.rs
+++ b/src/koans/array.rs
@@ -98,6 +98,7 @@ fn for_loops() {
     let mut y: u64 = 1;
     for x in &arr {
         assert!(*x == y);
+        __
     }
 }
 


### PR DESCRIPTION
This is a very simple fix for https://github.com/crazymykl/rust-koans/issues/40 - just adding `__` to hint that you need to increment `y`.